### PR TITLE
Fix: Popover does not close when clicking outside in SwitchSpace

### DIFF
--- a/apps/client/src/features/space/components/sidebar/switch-space.tsx
+++ b/apps/client/src/features/space/components/sidebar/switch-space.tsx
@@ -13,7 +13,7 @@ interface SwitchSpaceProps {
 
 export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
   const navigate = useNavigate();
-  const [opened, { close, open }] = useDisclosure(false);
+  const [opened, { close, open, toggle }] = useDisclosure(false);
 
   const handleSelect = (value: string) => {
     if (value) {
@@ -29,6 +29,7 @@ export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
       withArrow
       shadow="md"
       opened={opened}
+      onChange={toggle}
     >
       <Popover.Target>
         <Button


### PR DESCRIPTION
It was necessary to switch the state by onChange because it is a control component. 
ref: https://github.com/mantinedev/mantine/issues/7019